### PR TITLE
Fix infinite loop in sortTables

### DIFF
--- a/src/schema/create-schema-queries.ts
+++ b/src/schema/create-schema-queries.ts
@@ -110,6 +110,7 @@ const sortTables = (tables: Table[]): Table[] => {
         .filter(
           column =>
             column.foreign_key_table &&
+            column.foreign_key_table !== table.name &&
             !isDirectusTable(column.foreign_key_table) &&
             tableNames.includes(column.foreign_key_table)
         )


### PR DESCRIPTION
Table with a self-referential foreign key caused an infinite loop in sortTables.

This was only an issue in my case with sortTables(fileState) but not sortTables(dbState);