### PR TITLE
Fixed npx ts-node (shebang) problem on linux

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx ts-node
+#!/usr/bin/env -S npx ts-node
 
 import yargs from "yargs/yargs";
 import { initDb } from "./database/connect";


### PR DESCRIPTION
On Linux, it is not possible to use multiple arguments in the shebang. 

Gives the error: 
```
/usr/bin/env: ‘npx ts-node’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```

This PR fixes the problem.