### PR TITLE
[FEATURE] Adds support to optionally migrate directus tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Optional arguments:
 - **migrationsDir** - path to the directory to write migrations in. Defaults to **src/migrations**
 - **format** (javascript/typescript) - whether to generate the migration as a JavaScript or a TypeScript file. Defaults to **javascript**
 - **preview** - whether to run the script to see the diff only, but without writing to the state file or creating the actual migration. Exception: if this is the first run of the script, the state file will be created. Defaults to **false**
+- **allowedDirectusTables** - A list of allowed directus tables, separated by comma (i.e directus_users,directus_files)
 
 ## Disclaimer
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,12 @@ yargs(process.argv.slice(2)).command<CLIOptions>(
         describe:
           "Execute the diff, but don't write to the file-system. !!Exception: if this is the first run of the script, the state file will be created!!",
         default: false,
+      })
+      .option("allowedDirectusTables", {
+        type: "string",
+        describe:
+          "A list of allowed directus tables, separated by comma (i.e directus_users,directus_files)",
+        default: "",
       }),
   async argv => {
     initDb(argv.envFile);

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -13,7 +13,7 @@ export default async function migrate(options: CLIOptions): Promise<void> {
   const hasStateFile = await stateFileExits(options.stateFile);
 
   const dbDataState = await readData();
-  const dbSchemaState = await readSchema();
+  const dbSchemaState = await readSchema(options.allowedDirectusTables);
 
   if (!hasStateFile) {
     log.message(

--- a/src/schema/read-schema.ts
+++ b/src/schema/read-schema.ts
@@ -7,13 +7,16 @@ import log from "../utils/logger";
 /**
  * Reads the current schema of the database
  */
-export default async function readSchema(): Promise<SchemaState> {
+export default async function readSchema(allowedDirectusTables: string): Promise<SchemaState> {
   log.message("loading", "Reading your database schema");
 
   const inspector = SchemaInspector(db());
+  const allowedTables = allowedDirectusTables.length ? allowedDirectusTables.split(',') : [];
 
   // Directus will take care of the system tables, so we exclude them
-  const columnDefs = (await inspector.columnInfo()).filter(col => !isDirectusTable(col.table));
+  const columnDefs = (await inspector.columnInfo()).filter(col =>
+    allowedDirectusTables.includes(col.table) || !isDirectusTable(col.table)
+  );
 
   const state = columnDefs.reduce((result, def) => {
     const table = result.find(table => table.name === def.table);

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -5,4 +5,5 @@ export type CLIOptions = {
   format: "typescript" | "javascript";
   envFile: string;
   preview?: boolean;
+  allowedDirectusTables: string;
 };


### PR DESCRIPTION
## Description
- It basically enables migrations on given list of directus tables.
- Adds a new argument `--allowedDirectusTables` which takes a string of comma separated table names (i.e. `directus_users,directus_files`)

## Reason / Use Case
Directus tables are allowed to be modified, in my case, I need a Directus User from `directus_users` to have a one-to-many relationship with one of my collections. This works fine, but we needed to be able to migrate that change as well.